### PR TITLE
Fix serialization for embeds/refers many

### DIFF
--- a/src/LucidMongo/Model/Mixins/Serializer.js
+++ b/src/LucidMongo/Model/Mixins/Serializer.js
@@ -26,7 +26,9 @@ Serializer.toJSON = function () {
   return _(this.attributes)
   .thru(removeSafeFields)
   .transform((result, value, key) => {
-    result[key] = this.getFormatedField(key, this[key])
+    if (!_.isFunction(this[key])) {
+      result[key] = this.getFormatedField(key, this[key])
+    }
   })
   .merge(this.initializeComputedProperties())
   .merge(this.serializeRelations())

--- a/src/LucidMongo/Model/Mixins/Serializer.js
+++ b/src/LucidMongo/Model/Mixins/Serializer.js
@@ -28,6 +28,8 @@ Serializer.toJSON = function () {
   .transform((result, value, key) => {
     if (!_.isFunction(this[key])) {
       result[key] = this.getFormatedField(key, this[key])
+    } else {
+      result[key] = this.getFormatedField(key, this.$attributes[key])
     }
   })
   .merge(this.initializeComputedProperties())


### PR DESCRIPTION
Currently if there are embeds/refers many relations and they are not loaded using with('...') then during serialization I get serialized functions instead.
````
{ _id: '8m5bR',
  name: 'Alice',
  createdAt: '2017-07-29T07:17:16.522Z',
  updatedAt: '2017-07-29T07:17:16.609Z',
  posts: [Function: posts]
}
````